### PR TITLE
Add release job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,6 +9,9 @@ defaults:
     shell: bash
 
 jobs:
+  # The build job generates the distribution files
+  # and uploads the artifacts to the current build
+  # pipeline
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -67,10 +70,15 @@ jobs:
             dist-electron/*.rpm
             dist-electron/*.exe
 
+  # The release job will upload the artifacts
+  # to a newly created release draft.
+  # As long as the commit has a tag assigned to it.
   release:
     name: Release
     runs-on: ubuntu-latest
     needs: build
+    # This should only get run if there is a tag assigned to the commit.
+    # The action will not run when one or more of the 'build' jobs has failed.
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download Build Artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build and Release
 
 on:
   - push
@@ -43,7 +43,7 @@ jobs:
       - name: Run Tests
         run: npm run test
 
-      - name: Build
+      - name: Distribute
         run: if [ ! -z "$CSC_LINK" ] ; then npm run dist ; else unset CSC_LINK && unset WIN_CSC_LINK && npm run dist --publish=never ; fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,3 +66,27 @@ jobs:
             dist-electron/*.deb
             dist-electron/*.rpm
             dist-electron/*.exe
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+
+      - name: List files
+        id: list
+        run: echo ::set-output name=files::$(ls | cat)
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release ${{ github.ref }}
+          draft: true
+          generate_release_notes: true
+          prerelease: false
+          files: ${{ steps.list.outputs.files }}


### PR DESCRIPTION
This will add a newly created release job, which drafts a new release every time a tagged commit gets pushed.